### PR TITLE
Do not write log output to console

### DIFF
--- a/advert/advert.go
+++ b/advert/advert.go
@@ -19,29 +19,31 @@ import (
 var AdvertCmd = &cli.Command{
 	Name:  "advert",
 	Usage: "Show information about an advertisement from a specified publisher",
-	ArgsUsage: "The publisher's endpoint address in form of libp2p multiaddr info.\n" +
-		"       Example GraphSync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
-		"       Example HTTP:      /ip4/1.2.3.4/tcp/1234/http/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
 	Description: `Advertisement CIDs may be specified using the -cid flag, or --head to get the latest advertisement.
 Multiple CIDs may be specified to fetch multiple advertisements. Example Usage:
 
     advert
+		-ai /dns4/sp.example.com/tcp/17162/p2p/12D3KooWLjeDyvuv7rbfG2wWNvWn7ybmmU88PirmSckuqCgXBAph \
         -cid baguqeeradjagxlgpsy3xn2jrx52us5tl3mp5n5kq6kkg2ul3i6xzyrujbhbq \
-        -cid baguqeerazru3iegjkmjj45xfrheasxfxm4vwxotydl6mpt52zvnv5rx42ssq \
-        /ip4/212.248.62.42/tcp/17162/p2p/12D3KooWCYL6mn3p7W5WoaC3yYfbsovaDkQcpyxMFG9PtJUmSjzF
-
-Note: The publisher's address info must be specified as the last argument.
+        -cid baguqeerazru3iegjkmjj45xfrheasxfxm4vwxotydl6mpt52zvnv5rx42ssq
 
 If no CIDs are specified then CIDs are read from stdin, one per line.
 
-    cat cids.txt | advert /ip4/212.248.62.42/tcp/17162/p2p/12D3KooWCYL6mn3p7W5WoaC3yYfbsovaDkQcpyxMFG9PtJUmSjzF
+    cat cids.txt | advert -ai /dns4/sp.example.com/tcp/17162/p2p/12D3KooWLjeDyvuv7rbfG2wWNvWn7ybmmU88PirmSckuqCgXBAph
 `,
 	Flags:  advertFlags,
-	Before: beforeAdvert,
 	Action: advertAction,
 }
 
 var advertFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name: "addr-info",
+		Usage: "Publisher's address info in form of libp2p multiaddr info.\n" +
+			"Example GraphSync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
+			"Example HTTP:      /ip4/1.2.3.4/tcp/1234/http/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+		Aliases:  []string{"ai"},
+		Required: true,
+	},
 	&cli.StringSliceFlag{
 		Name:     "cid",
 		Usage:    "Specify advertisement CID to fetch, multiple OK",
@@ -71,15 +73,8 @@ var advertFlags = []cli.Flag{
 	},
 }
 
-func beforeAdvert(cctx *cli.Context) error {
-	if !cctx.Args().Present() {
-		return cli.Exit("The advertisement publisher address info must be specified as argument.", 1)
-	}
-	return nil
-}
-
 func advertAction(cctx *cli.Context) error {
-	addrInfo, err := peer.AddrInfoFromString(cctx.Args().First())
+	addrInfo, err := peer.AddrInfoFromString(cctx.String("addr-info"))
 	if err != nil {
 		return fmt.Errorf("bad pub-addr-info: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
-	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-car/v2 v2.10.0
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipni/go-libipni v0.0.7
@@ -72,6 +71,7 @@ require (
 	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
 	github.com/ipfs/go-libipfs v0.6.2 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
+	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/ipfs/go-merkledag v0.10.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.1 // indirect

--- a/internal/adpub/options.go
+++ b/internal/adpub/options.go
@@ -21,7 +21,7 @@ func newOptions(o ...Option) (*options, error) {
 	opts := &options{
 		entriesRecurLimit: selector.RecursionLimitNone(),
 		topic:             "/indexer/ingest/mainnet",
-		maxSyncRetry:      10,
+		maxSyncRetry:      5,
 		syncRetryBackoff:  500 * time.Millisecond,
 	}
 	for _, apply := range o {


### PR DESCRIPTION
- Structured log output should not be wrtiien to the console. Use formatted text instead since that is more appropriate for users.
- Fix retry counter when retrying to sync ads and entries.
- Use a flag instead of positional arg to specify addr-info in advert command. This makes it more clear what is being specified.