### PR TITLE
Get ad entries data as needed

### DIFF
--- a/pkg/adpub/options.go
+++ b/pkg/adpub/options.go
@@ -1,42 +1,45 @@
 package adpub
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 )
 
-type (
-	Option func(*options) error
+type config struct {
+	entriesDepthLimit selector.RecursionLimit
+	maxSyncRetry      uint64
+	syncRetryBackoff  time.Duration
+	topic             string
+}
 
-	options struct {
-		entriesRecurLimit selector.RecursionLimit
-		topic             string
-		maxSyncRetry      uint64
-		syncRetryBackoff  time.Duration
-	}
-)
+// Option is a function that sets a value in a config.
+type Option func(*config) error
 
-func newOptions(o ...Option) (*options, error) {
-	opts := &options{
-		entriesRecurLimit: selector.RecursionLimitNone(),
+// getOpts creates a config and applies Options to it.
+func getOpts(opts []Option) (config, error) {
+	cfg := config{
+		entriesDepthLimit: selector.RecursionLimitNone(),
 		topic:             "/indexer/ingest/mainnet",
-		maxSyncRetry:      5,
+		maxSyncRetry:      3,
 		syncRetryBackoff:  500 * time.Millisecond,
 	}
-	for _, apply := range o {
-		if err := apply(opts); err != nil {
-			return nil, err
+
+	for i, opt := range opts {
+		if err := opt(&cfg); err != nil {
+			return config{}, fmt.Errorf("option %d failed: %s", i, err)
 		}
 	}
-	return opts, nil
+	return cfg, nil
 }
 
 // WithSyncRetryBackoff sets the length of time to wait before retrying a faild
 // sync. Defaults to 500ms if unset.
 func WithSyncRetryBackoff(d time.Duration) Option {
-	return func(o *options) error {
-		o.syncRetryBackoff = d
+	return func(c *config) error {
+		c.syncRetryBackoff = d
 		return nil
 	}
 }
@@ -44,8 +47,8 @@ func WithSyncRetryBackoff(d time.Duration) Option {
 // WithMaxSyncRetry sets the maximum number of times to retry a failed sync.
 // Defaults to 10 if unset.
 func WithMaxSyncRetry(r uint64) Option {
-	return func(o *options) error {
-		o.maxSyncRetry = r
+	return func(c *config) error {
+		c.maxSyncRetry = r
 		return nil
 	}
 }
@@ -53,17 +56,24 @@ func WithMaxSyncRetry(r uint64) Option {
 // WithTopicName sets the topic name on which the provider announces advertised
 // content. Defaults to '/indexer/ingest/mainnet'.
 func WithTopicName(topic string) Option {
-	return func(o *options) error {
-		o.topic = topic
+	return func(c *config) error {
+		c.topic = topic
 		return nil
 	}
 }
 
-// WithEntriesRecursionLimit sets the recursion limit when syncing
-// advertisement entries chain. Defaults to no limit.
-func WithEntriesRecursionLimit(limit selector.RecursionLimit) Option {
-	return func(o *options) error {
-		o.entriesRecurLimit = limit
+// WithEntriesDepthLimit sets the depth limit when syncing an
+// advertisement entries chain. Setting to 0 means no limit.
+func WithEntriesDepthLimit(depthLimit int64) Option {
+	return func(c *config) error {
+		if depthLimit < 0 {
+			return errors.New("ad entries depth limit cannot be negative")
+		}
+		if depthLimit == 0 {
+			c.entriesDepthLimit = selector.RecursionLimitNone()
+		} else {
+			c.entriesDepthLimit = selector.RecursionLimitDepth(depthLimit)
+		}
 		return nil
 	}
 }

--- a/pkg/distance/distance.go
+++ b/pkg/distance/distance.go
@@ -58,7 +58,7 @@ func distanceAction(cctx *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("bad old cid: %w", err)
 	}
-	provClient, err := adpub.MakeClient(*addrInfo, cctx.String("topic"), 0)
+	provClient, err := adpub.NewClient(*addrInfo, adpub.WithTopicName(cctx.String("topic")))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Advertisement entries data was being fetched along with each ad in the chain. If fetching a large number of ads this can inefficient if not all the entries are needed. Instead, only fetch the entries data for each as at the time the entries data is needed.

This also removes unnecessary code and data from the publisher client.