### PR TITLE
Add signature verfication when getting ads

### DIFF
--- a/cmd/ipni/ipni.go
+++ b/cmd/ipni/ipni.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ipni/ipni-cli/pkg/find"
 	"github.com/ipni/ipni-cli/pkg/provider"
 	"github.com/ipni/ipni-cli/pkg/spaddr"
-	"github.com/ipni/ipni-cli/pkg/verifyingest"
+	"github.com/ipni/ipni-cli/pkg/verify"
 	"github.com/urfave/cli/v2"
 )
 
@@ -25,7 +25,7 @@ func main() {
 			find.FindCmd,
 			provider.ProviderCmd,
 			spaddr.SPAddrCmd,
-			verifyingest.VerifyIngestCmd,
+			verify.VerifyCmd,
 		},
 	}
 

--- a/pkg/adpub/client_store.go
+++ b/pkg/adpub/client_store.go
@@ -39,7 +39,7 @@ type Advertisement struct {
 	ExtendedProvider *schema.ExtendedProvider
 	// SigErr is the signature validation error. Nil if signature is valid.
 	SigErr error
-	// SignerID is the peer.ID of the of the signer
+	// SignerID is the peer.ID of the of the signer.
 	SignerID peer.ID
 }
 

--- a/pkg/adpub/client_store.go
+++ b/pkg/adpub/client_store.go
@@ -26,7 +26,7 @@ type ClientStore struct {
 	ipld.LinkSystem
 }
 
-// TODO: replace Advertisement type with schema.Advertisement
+// Advertisement contains information about a schema.Advertisement
 type Advertisement struct {
 	ID               cid.Cid
 	PreviousID       cid.Cid
@@ -34,10 +34,13 @@ type Advertisement struct {
 	ContextID        []byte
 	Metadata         []byte
 	Addresses        []string
-	Signature        []byte
 	Entries          *EntriesIterator
 	IsRemove         bool
 	ExtendedProvider *schema.ExtendedProvider
+	// SigErr is the signature validation error. Nil if signature is valid.
+	SigErr error
+	// SignerID is the peer.ID of the of the signer
+	SignerID peer.ID
 }
 
 func (a *Advertisement) HasEntries() bool {
@@ -144,7 +147,6 @@ func (s *ClientStore) getAdvertisement(ctx context.Context, id cid.Cid) (*Advert
 		Metadata:         ad.Metadata,
 		Addresses:        ad.Addresses,
 		PreviousID:       prevCid,
-		Signature:        ad.Signature,
 		IsRemove:         ad.IsRm,
 		ExtendedProvider: ad.ExtendedProvider,
 	}
@@ -160,6 +162,8 @@ func (s *ClientStore) getAdvertisement(ctx context.Context, id cid.Cid) (*Advert
 			}
 		}
 	}
+
+	a.SignerID, a.SigErr = ad.VerifySignature()
 
 	return a, nil
 }
@@ -198,5 +202,3 @@ func (s *ClientStore) distance(ctx context.Context, oldestCid, newestCid cid.Cid
 	}
 	return count, nil
 }
-
-// TODO: add advertisement signature verification

--- a/pkg/advert/advert.go
+++ b/pkg/advert/advert.go
@@ -91,7 +91,7 @@ func advertAction(cctx *cli.Context) error {
 			}
 			cid, err := cid.Decode(cidStr)
 			if err != nil {
-				return fmt.Errorf("bad advertisement CID arqument: %w", err)
+				return fmt.Errorf("bad advertisement CID: %w", err)
 			}
 			adCids = append(adCids, cid)
 		}
@@ -120,7 +120,7 @@ func advertAction(cctx *cli.Context) error {
 			}
 			cid, err := cid.Decode(cidStr)
 			if err != nil {
-				return fmt.Errorf("bad advertisement CID argument: %w", err)
+				return fmt.Errorf("bad advertisement CID: %w", err)
 			}
 			adCids = append(adCids, cid)
 		}
@@ -168,6 +168,21 @@ func advertAction(cctx *cli.Context) error {
 			}
 		} else {
 			fmt.Println("   None")
+		}
+		fmt.Print("Signature: ")
+		if ad.SigErr != nil {
+			fmt.Println("❌ invalid:", ad.SigErr)
+		} else {
+			fmt.Println("✅ valid")
+			fmt.Print("Signed by: ")
+			switch ad.SignerID {
+			case ad.ProviderID:
+				fmt.Println("content provider")
+			case addrInfo.ID:
+				fmt.Println("advertisement publisher")
+			default:
+				fmt.Println("⚠️  Unknown:", ad.SignerID)
+			}
 		}
 
 		if ad.IsRemove {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,14 +19,13 @@ import (
 )
 
 var ProviderCmd = &cli.Command{
-	Name: "provider",
-	Usage: "Show information about one or more providers known to an indexer. " +
-		"Reads provider IDs from stdin if none are specified.",
-	Description: `The -v flag inverts the selection of providers, and shows all that are not specified.
-This can be used to filter out provideres from the returned list.
+	Name:  "provider",
+	Usage: "Show information about providers known to an indexer.",
+	Description: `Get information about one or more providers from the specified indexer. An optional --distance flag will calculate the distance from the last seen advertisement to the provider's current head advertisement.
 
-Here is an example that shows using the output of one provider command to filter the output of
-another, to see which providers cid.contact knows about that dev.cid.contact does not:
+The --invert flag inverts the selection of providers, and shows all that are not specified. This can be used to filter out provideres from the returned list.
+
+Here is an example that shows using the output of one provider command to filter the output of another, to see which providers cid.contact knows about that dev.cid.contact does not:
 
     provider --all -i dev.cid.contact -id | provider -invert -i cid.contact -id
 `,
@@ -43,9 +42,8 @@ var providerFlags = []cli.Flag{
 		Value:   "http://localhost:3000",
 	},
 	&cli.StringSliceFlag{
-		Name:    "pid",
-		Usage:   "Provider's peer ID, multiple allowed",
-		Aliases: []string{"p"},
+		Name:  "pid",
+		Usage: "Provider's peer ID, multiple allowed. Reads IDs from stdin if none are specified.",
 	},
 	&cli.BoolFlag{
 		Name:    "all",
@@ -63,7 +61,7 @@ var providerFlags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:  "invert",
-		Usage: "Invert selection, show all providers except those specified",
+		Usage: "Invert selection to show all providers except those specified",
 	},
 }
 

--- a/pkg/verify/ingest.go
+++ b/pkg/verify/ingest.go
@@ -1,4 +1,4 @@
-package verifyingest
+package verify
 
 import (
 	"errors"
@@ -30,8 +30,8 @@ var (
 	printUnindexedMhs bool
 )
 
-var VerifyIngestCmd = &cli.Command{
-	Name: "verify-ingest",
+var verifyIngestSubCmd = &cli.Command{
+	Name: "ingest",
 	Usage: "Verifies an indexer's ingestion of multihashes. " +
 		"Multihashes can be read from a publisher, from a CAR file, or from a CARv2 Index",
 	Description: `This command verifies whether a list of multihashes are ingested by an indexer and have the 
@@ -65,20 +65,20 @@ Example usage:
 
 * Verify ingest from provider's GraphSync publisher endpoint for a specific advertisement CID,
   selecting 50% of available multihashes using deterministic random number generator, seeded with '1413':
-	./verifyingest --provider-id 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ \
+	./verify ingest --provider-id 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ \
 		--indexer https://cid.contact \
 		--ad-cid baguqeeqqcbuegh2hzk7sukqpsz24wg3tk4 \
 		--sampling-prob 0.5 --rng-seed 1413
 
 * Verify ingestion from CAR file, selecting 50% of available multihashes using a deterministic 
   random number generator, seeded with '1413':
-	./verifyingest --provider-id 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ \
+	./verify ingest --provider-id 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ \
 		--from-car my-dag.car \
 		--indexer 192.168.2.100:3000 \
 		--sampling-prob 0.5 --rng-seed 1413
 
 * Verify ingestion from CARv2 index file using all available multihashes:
-	./verifyingest --provider-id 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ \
+	./verify ingest --provider-id 12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ \
 		--from-car my-idx.idx \
 		--indexer 192.168.2.100:3000
 

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -1,0 +1,13 @@
+package verify
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var VerifyCmd = &cli.Command{
+	Name:  "verify",
+	Usage: "Verifies advertised content validity and queribility from an indexer",
+	Subcommands: []*cli.Command{
+		verifyIngestSubCmd,
+	},
+}

--- a/pkg/verify/verify.go
+++ b/pkg/verify/verify.go
@@ -6,7 +6,7 @@ import (
 
 var VerifyCmd = &cli.Command{
 	Name:  "verify",
-	Usage: "Verifies advertised content validity and queribility from an indexer",
+	Usage: "Verifies advertised content validity and queryability from an indexer",
 	Subcommands: []*cli.Command{
 		verifyIngestSubCmd,
 	},


### PR DESCRIPTION
When ads are read, verifiy their signature and record the signer's ID.

Other changes:
- Rename verify-indest to verify with ingest sub-command
- Fix errors in help text