### PR TITLE
Default to using double hashed queries

### DIFF
--- a/pkg/find/find.go
+++ b/pkg/find/find.go
@@ -48,7 +48,7 @@ var findFlags = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:     "dhstore",
-		Usage:    "URL of double-hashed store, if different from indexer",
+		Usage:    "URL of double-hashed (reader-private) store, if different from indexer",
 		EnvVars:  []string{"DHSTORE"},
 		Required: false,
 	},
@@ -57,12 +57,12 @@ var findFlags = []cli.Flag{
 		Usage: "Only show provider's peer ID from each result",
 	},
 	&cli.BoolFlag{
-		Name:  "no-dh",
-		Usage: "Do plain query only.",
+		Name:  "no-priv",
+		Usage: "Do no use reader-privacy for queries.",
 	},
 	&cli.BoolFlag{
 		Name:  "fallback",
-		Usage: "Do plain query only if indexer does not support double-hashing",
+		Usage: "Do non-private query only if the indexer does not support reader-privacy",
 	},
 }
 
@@ -89,7 +89,7 @@ func findAction(cctx *cli.Context) error {
 		mhs = append(mhs, c.Hash())
 	}
 
-	if cctx.Bool("no-dh") {
+	if cctx.Bool("no-priv") {
 		return clearFind(cctx, mhs)
 	}
 	return dhFind(cctx, mhs)
@@ -126,6 +126,7 @@ func dhFind(cctx *cli.Context, mhs []multihash.Multihash) error {
 	if resp == nil && cctx.Bool("fallback") {
 		return clearFind(cctx, mhs)
 	}
+	fmt.Println("🔒 Reader privacy enabled")
 	return printResults(cctx, resp)
 }
 

--- a/pkg/find/find.go
+++ b/pkg/find/find.go
@@ -2,10 +2,13 @@ package find
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipni/go-libipni/apierror"
 	"github.com/ipni/go-libipni/find/client"
 	"github.com/ipni/go-libipni/find/model"
 	"github.com/ipni/go-libipni/metadata"
@@ -43,9 +46,23 @@ var findFlags = []cli.Flag{
 		Aliases: []string{"i"},
 		Value:   "http://localhost:3000",
 	},
+	&cli.StringFlag{
+		Name:     "dhstore",
+		Usage:    "URL of double-hashed store, if different from indexer",
+		EnvVars:  []string{"DHSTORE"},
+		Required: false,
+	},
 	&cli.BoolFlag{
 		Name:  "id-only",
 		Usage: "Only show provider's peer ID from each result",
+	},
+	&cli.BoolFlag{
+		Name:  "no-dh",
+		Usage: "Do plain query only.",
+	},
+	&cli.BoolFlag{
+		Name:  "fallback",
+		Usage: "Do plain query only if indexer does not support double-hashing",
 	},
 }
 
@@ -72,6 +89,47 @@ func findAction(cctx *cli.Context) error {
 		mhs = append(mhs, c.Hash())
 	}
 
+	if cctx.Bool("no-dh") {
+		return clearFind(cctx, mhs)
+	}
+	return dhFind(cctx, mhs)
+}
+
+func dhFind(cctx *cli.Context, mhs []multihash.Multihash) error {
+	dhURL := cctx.String("dhstore")
+	if dhURL == "" {
+		dhURL = cctx.String("indexer")
+	}
+
+	cl, err := client.NewDHashClient(dhURL, cctx.String("indexer"))
+	if err != nil {
+		return err
+	}
+
+	var resp *model.FindResponse
+	for _, mh := range mhs {
+		r, err := cl.Find(cctx.Context, mh)
+		if err != nil {
+			// TODO: Look for error that specifies double-hashing not supported.
+			var ae *apierror.Error
+			if errors.As(err, &ae) && ae.Status() == http.StatusNotFound {
+				continue
+			}
+			return err
+		}
+		if resp == nil {
+			resp = r
+		} else {
+			resp.MultihashResults = append(resp.MultihashResults, r.MultihashResults...)
+		}
+	}
+	if resp == nil && cctx.Bool("fallback") {
+		return clearFind(cctx, mhs)
+	}
+	return printResults(cctx, resp)
+}
+
+func clearFind(cctx *cli.Context, mhs []multihash.Multihash) error {
 	cl, err := client.New(cctx.String("indexer"))
 	if err != nil {
 		return err
@@ -87,7 +145,11 @@ func findAction(cctx *cli.Context) error {
 		return err
 	}
 
-	if len(resp.MultihashResults) == 0 {
+	return printResults(cctx, resp)
+}
+
+func printResults(cctx *cli.Context, resp *model.FindResponse) error {
+	if resp == nil || len(resp.MultihashResults) == 0 {
 		fmt.Println("index not found")
 		return nil
 	}


### PR DESCRIPTION
The find command uses double-hashed queries by default. If the `--no-priv` flag is given, then only plain (non-dh) queries are done. If the `--fallback` flag is given, then a double-hashed query is tried first, and if no results were returned for any dh query, then a plain query is tried.

In the future, the plain query should only be tried if the indexer does not support double-hashing, not because no results were returned.

Fixes #19