### PR TITLE
New ads command contains get, list, dist subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 bin/
 ipni
+!ipni/
 
 *~
 *.car

--- a/README.md
+++ b/README.md
@@ -24,43 +24,50 @@ ipni --help
 ## Examples
 
 Here are a few examples that use the following commands:
-- `advert`    Show information about an advertisement from a specified publisher
-- `distance`  Determine the distance between two advertisements in a chain
+- `ads`       Show advertisements on a chain from a specified publisher
+  - `get`         Show information about an advertisement from a specified publisher
+  - `list`        List advertisements from latest to earlier from a specified publisher
+  - `dist`        Determine the distance between two advertisements in a chain
 - `find`      Find value by CID or multihash in indexer
 - `provider`  Show information about providers known to an indexer.
 - `spaddr`    Get storage provider p2p ID and address from lotus gateway
 - `verify`    Verifies advertised content validity and queryability from an indexer
 
-### `advert`
+### `ads get`
 - Show the latest advertisement from a publisher:
 ```sh
-ipni advert --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys --head
+ipni ads get --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys --head
 ```
 - Show information about a specific advertisement:
 ```
-./ipni advert --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
+./ipni ads get --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
     --cid=baguqeerank3iclae2u4lin3vj2avuory3ny67tldh2cd5uodsgsdl6uawz3a
 ```
 - Show information about multiple advertisements:
 ```sh
-ipni advert --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
+ipni ads get --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
     --cid=baguqeerank3iclae2u4lin3vj2avuory3ny67tldh2cd5uodsgsdl6uawz3a
     --cid=baguqeera3aylz3gkoxtkmqdwulxlaqbudf7nhdomfpyjqij236pwehrngngq
 ```
 - Get ads from a list of CIDs in a file:
 ```sh
-cat ad-cids-list.txt | ipni advert /dns4/ads.example.com/tcp/24001/p2p/<publisher-p2p-id>
+cat ad-cids-list.txt | ipni add get /dns4/ads.example.com/tcp/24001/p2p/<publisher-p2p-id>
+```
+### `ads list`
+- List the 10 most recent advertisements from a provider:
+```sh
+ipni ads list -n 10 --ai=/ip4/38.70.220.112/tcp/10201/p2p/12D3KooWEAcRJ5fYjuavKgAhu79juR7mgaznSZxsm2RRUBiWurv9
 ```
 
-### `distance`
+### `ads dist`
 - Get distance from an advertisement to the head of the advertisement chain:
 ```sh
-ipni distance --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
+ipni ads dist --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
     --start=baguqeera3aylz3gkoxtkmqdwulxlaqbudf7nhdomfpyjqij236pwehrngngq
 ```
 - Find the distance between 2 advertisements on a publisher's chain:
 ```sh
-ipni distance  --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
+ipni ads dist  --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
     --start=baguqeera3aylz3gkoxtkmqdwulxlaqbudf7nhdomfpyjqij236pwehrngngq \
     --end=baguqeerage4rh6yqy4u37x7i337q57wrwfls5ihiei6l72rr6ezrw5vcucea
 ```

--- a/cmd/ipni/ipni.go
+++ b/cmd/ipni/ipni.go
@@ -5,8 +5,7 @@ import (
 	"os"
 
 	version "github.com/ipni/ipni-cli"
-	"github.com/ipni/ipni-cli/pkg/advert"
-	"github.com/ipni/ipni-cli/pkg/distance"
+	"github.com/ipni/ipni-cli/pkg/ads"
 	"github.com/ipni/ipni-cli/pkg/find"
 	"github.com/ipni/ipni-cli/pkg/provider"
 	"github.com/ipni/ipni-cli/pkg/spaddr"
@@ -20,8 +19,7 @@ func main() {
 		Usage:   "Commands to interact with IPNI indexers and index providers",
 		Version: version.Version,
 		Commands: []*cli.Command{
-			advert.AdvertCmd,
-			distance.DistanceCmd,
+			ads.AdsCmd,
 			find.FindCmd,
 			provider.ProviderCmd,
 			spaddr.SPAddrCmd,

--- a/pkg/ads/ads.go
+++ b/pkg/ads/ads.go
@@ -1,0 +1,15 @@
+package ads
+
+import (
+	"github.com/urfave/cli/v2"
+)
+
+var AdsCmd = &cli.Command{
+	Name:  "ads",
+	Usage: "Show advertisements on a chain from a specified publisher",
+	Subcommands: []*cli.Command{
+		adsGetSubCmd,
+		adsListSubCmd,
+		adsDistSubCmd,
+	},
+}

--- a/pkg/ads/dist.go
+++ b/pkg/ads/dist.go
@@ -1,4 +1,4 @@
-package distance
+package ads
 
 import (
 	"fmt"
@@ -9,23 +9,16 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var DistanceCmd = &cli.Command{
-	Name:        "distance",
+var adsDistSubCmd = &cli.Command{
+	Name:        "dist",
 	Usage:       "Determine the distance between two advertisements in a chain",
 	Description: "Sepcify the start and optional end advertisement CIDs. If end CID is not specified use the latest advertisement",
-	Flags:       distanceFlags,
-	Action:      distanceAction,
+	Flags:       adsDistFlags,
+	Action:      adsDistAction,
 }
 
-var distanceFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name: "addr-info",
-		Usage: "Publisher's address info in form of libp2p multiaddr info.\n" +
-			"Example GraphSync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
-			"Example HTTP:      /ip4/1.2.3.4/tcp/1234/http/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
-		Aliases:  []string{"ai"},
-		Required: true,
-	},
+var adsDistFlags = []cli.Flag{
+	addrInfoFlag,
 	&cli.StringFlag{
 		Name:     "start",
 		Usage:    "CID of earliest advertisement in chain",
@@ -40,15 +33,10 @@ var distanceFlags = []cli.Flag{
 		Usage:   "Output only the distance",
 		Aliases: []string{"q"},
 	},
-	&cli.StringFlag{
-		Name:    "topic",
-		Usage:   "Topic on which index advertisements are published. Only needed if connecting via Graphsync with non-standard topic.",
-		Value:   "/indexer/ingest/mainnet",
-		Aliases: []string{"t"},
-	},
+	topicFlag,
 }
 
-func distanceAction(cctx *cli.Context) error {
+func adsDistAction(cctx *cli.Context) error {
 	addrInfo, err := peer.AddrInfoFromString(cctx.String("addr-info"))
 	if err != nil {
 		return fmt.Errorf("bad pub-addr-info: %w", err)

--- a/pkg/ads/flags.go
+++ b/pkg/ads/flags.go
@@ -1,0 +1,19 @@
+package ads
+
+import "github.com/urfave/cli/v2"
+
+var addrInfoFlag = &cli.StringFlag{
+	Name: "addr-info",
+	Usage: "Publisher's address info in form of libp2p multiaddr info.\n" +
+		"Example GraphSync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
+		"Example HTTP:      /ip4/1.2.3.4/tcp/1234/http/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+	Aliases:  []string{"ai"},
+	Required: true,
+}
+
+var topicFlag = &cli.StringFlag{
+	Name:    "topic",
+	Usage:   "Topic on which index advertisements are published. Only needed if connecting via Graphsync with non-standard topic.",
+	Value:   "/indexer/ingest/mainnet",
+	Aliases: []string{"t"},
+}

--- a/pkg/ads/get.go
+++ b/pkg/ads/get.go
@@ -1,4 +1,4 @@
-package advert
+package ads
 
 import (
 	"bufio"
@@ -16,44 +16,31 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var AdvertCmd = &cli.Command{
-	Name:  "advert",
+var adsGetSubCmd = &cli.Command{
+	Name:  "get",
 	Usage: "Show information about an advertisement from a specified publisher",
 	Description: `Advertisement CIDs may be specified using the -cid flag, or --head to get the latest advertisement.
 Multiple CIDs may be specified to fetch multiple advertisements. Example Usage:
 
-    advert
+    ipni ads get \
 		-ai /dns4/sp.example.com/tcp/17162/p2p/12D3KooWLjeDyvuv7rbfG2wWNvWn7ybmmU88PirmSckuqCgXBAph \
         -cid baguqeeradjagxlgpsy3xn2jrx52us5tl3mp5n5kq6kkg2ul3i6xzyrujbhbq \
         -cid baguqeerazru3iegjkmjj45xfrheasxfxm4vwxotydl6mpt52zvnv5rx42ssq
 
 If no CIDs are specified then CIDs are read from stdin, one per line.
 
-    cat cids.txt | advert -ai /dns4/sp.example.com/tcp/17162/p2p/12D3KooWLjeDyvuv7rbfG2wWNvWn7ybmmU88PirmSckuqCgXBAph
+    cat cids.txt | ipni ads get -ai /dns4/sp.example.com/tcp/17162/p2p/12D3KooWLjeDyvuv7rbfG2wWNvWn7ybmmU88PirmSckuqCgXBAph
 `,
-	Flags:  advertFlags,
-	Action: advertAction,
+	Flags:  adsGetFlags,
+	Action: adsGetAction,
 }
 
-var advertFlags = []cli.Flag{
-	&cli.StringFlag{
-		Name: "addr-info",
-		Usage: "Publisher's address info in form of libp2p multiaddr info.\n" +
-			"Example GraphSync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
-			"Example HTTP:      /ip4/1.2.3.4/tcp/1234/http/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
-		Aliases:  []string{"ai"},
-		Required: true,
-	},
+var adsGetFlags = []cli.Flag{
+	addrInfoFlag,
 	&cli.StringSliceFlag{
 		Name:     "cid",
 		Usage:    "Specify advertisement CID to fetch, multiple OK",
 		Required: false,
-	},
-	&cli.StringFlag{
-		Name:    "topic",
-		Usage:   "Topic on which index advertisements are published. Only needed if connecting to provider via Graphsync endpoint.",
-		Value:   "/indexer/ingest/mainnet",
-		Aliases: []string{"t"},
 	},
 	&cli.BoolFlag{
 		Name:  "head",
@@ -71,9 +58,10 @@ var advertFlags = []cli.Flag{
 		Value:       100,
 		DefaultText: "100 (set to '0' for unlimited)",
 	},
+	topicFlag,
 }
 
-func advertAction(cctx *cli.Context) error {
+func adsGetAction(cctx *cli.Context) error {
 	addrInfo, err := peer.AddrInfoFromString(cctx.String("addr-info"))
 	if err != nil {
 		return fmt.Errorf("bad pub-addr-info: %w", err)

--- a/pkg/ads/list.go
+++ b/pkg/ads/list.go
@@ -1,0 +1,60 @@
+package ads
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipni/ipni-cli/pkg/adpub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/urfave/cli/v2"
+)
+
+var adsListSubCmd = &cli.Command{
+	Name:  "list",
+	Usage: "List advertisements from latest to earlier from a specified publisher",
+	Description: `Sepcify an optional latest advertisement CID, and list the requested number of advertisements from latest to earliest.
+Example Usage:
+
+    ipni ads list -n 10 --ai=/ip4/38.70.220.112/tcp/10201/p2p/12D3KooWEAcRJ5fYjuavKgAhu79juR7mgaznSZxsm2RRUBiWurv9
+`,
+	Flags:  adsListFlags,
+	Action: adsListAction,
+}
+
+var adsListFlags = []cli.Flag{
+	addrInfoFlag,
+	&cli.StringFlag{
+		Name:  "latest",
+		Usage: "CID of latest advertisement in chain to start list from. If not specified, use latest advertisement in the chain",
+	},
+	&cli.IntFlag{
+		Name:     "number",
+		Usage:    "Number of advertisements to list",
+		Aliases:  []string{"n"},
+		Required: true,
+	},
+	topicFlag,
+}
+
+func adsListAction(cctx *cli.Context) error {
+	addrInfo, err := peer.AddrInfoFromString(cctx.String("addr-info"))
+	if err != nil {
+		return fmt.Errorf("bad pub-addr-info: %w", err)
+	}
+
+	provClient, err := adpub.NewClient(*addrInfo, adpub.WithTopicName(cctx.String("topic")))
+	if err != nil {
+		return err
+	}
+
+	var latestCid cid.Cid
+	if cctx.String("latest") != "" {
+		latestCid, err = cid.Decode(cctx.String("latest"))
+		if err != nil {
+			return fmt.Errorf("bad cid: %w", err)
+		}
+	}
+
+	return provClient.List(cctx.Context, latestCid, cctx.Int("number"), os.Stdout)
+}

--- a/pkg/ads/list.go
+++ b/pkg/ads/list.go
@@ -30,7 +30,7 @@ var adsListFlags = []cli.Flag{
 	},
 	&cli.IntFlag{
 		Name:     "number",
-		Usage:    "Number of advertisements to list",
+		Usage:    "Number of advertisements to list. Specify 0 for all.",
 		Aliases:  []string{"n"},
 		Required: true,
 	},


### PR DESCRIPTION
The `ads` command replaces the `advert` and the `distance` command, and provides new list functionality.

- `ads`       Show advertisements on a chain from a specified publisher
  - `get`         Show information about an advertisement from a specified publisher
  - `list`        List advertisements from latest to earlier from a specified publisher
  - `dist`        Determine the distance between two advertisements in a chain
