### PR TITLE
Add distance tracking functionality to provider command 

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ ipni ads dist  --ai=/ip4/76.219.232.45/tcp/24001/p2p/12D3KooWPNbkEgjdBNeaCGpsgCr
 ### `find`
 - Ask cid.contact where to find CID `bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy`:
 ```sh
-ipni find -i cid.contact --cid bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy
+ipni find -i https://cid.contact --cid bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy
 ```
 - Ask cid.contact where to find multiple multihashes:
 ```sh
-./ipni find -i cid.contact \
+./ipni find -i https://cid.contact \
     --mh=2Drjgb5kxWdcTNfhfEC8F3Ltk4s16aAgG2aLnXxSdpiGTazLGE \
     --mh=2Drjgb4GmZ3cJGRunHYdHrmtgbmGoDuSMeN42gdU1jSiGmHVmA \
     --mh=2DrjgbJZxQgMTvWDG6ih2SNESWeoabccawmLwuFt1T59joGFxd
@@ -88,30 +88,30 @@ ipni find -i cid.contact --cid bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5w
 ### `provider`
 - Get all providers known by the indexer dev.cid.contact:
 ```
-ipni provider -i dev.cid.contact --all
+ipni provider -i https://dev.cid.contact --all
 ```
 - Get information about the provider with ID `QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC`
 ```
-ipni provider -i cid.contact -pid QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC
+ipni provider -i https://cid.contact -pid QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC
 ```
 ```
-echo QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC | ipni provider -i cid.contact
+echo QmQzqxhK82kAmKvARFZSkUVS6fo9sySaiogAnx5EnZ6ZmC | ipni provider -i https://cid.contact
 ```
 - Get information about the providers returned from find results:
 ```sh
-ipni find -i cid.contact --cid bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy --id-only | ipni provider -i cid.contact
+ipni find -i https://cid.contact --cid bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy --id-only | ipni provider -i https://cid.contact
 ```
 - See which providers cid.contact knows about that dev.cid.contact does not:
 ```sh 
-ipni provider --all -i dev.cid.contact -id | ipni provider -invert -i cid.contact -id
+ipni provider --all -i https://dev.cid.contact -id | ipni provider -invert -i https://cid.contact -id
 ```
 - Get combined information from multiple providers:
 ```
-$ ipni provider --all -i alva.dev.cid.contact -i cora.dev.cid.contact --id-only | wc -l
+$ ipni provider --all -i https://alva.dev.cid.contact -i https://cora.dev.cid.contact --id-only | wc -l
      405
-$ ipni provider --all -i alva.dev.cid.contact --id-only | wc -l
+$ ipni provider --all -i https://alva.dev.cid.contact --id-only | wc -l
      209
-> ipni provider --all -i cora.dev.cid.contact --id-only | wc -l
+> ipni provider --all -i https://cora.dev.cid.contact --id-only | wc -l
      196
 ```
 
@@ -124,7 +124,7 @@ $ ipni provider --all -i alva.dev.cid.contact --id-only | wc -l
 ### `verify ingest`
 - Verfy ingestion at cid.contact, of multihashes 
 ```
-./ipni verify ingest -i cid.contact \
+./ipni verify ingest -i https://cid.contact \
     --ad-cid=baguqeerank3iclae2u4lin3vj2avuory3ny67tldh2cd5uodsgsdl6uawz3a \
     --provider-id=12D3KooWPNbkEgjdBNeaCGpsgCrPRETe4uBZf1ShFXStobdN18ys \
     --batch-size=25 \

--- a/cmd/ipni/ipni.go
+++ b/cmd/ipni/ipni.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipni/ipni-cli"
 	"github.com/ipni/ipni-cli/pkg/ads"
 	"github.com/ipni/ipni-cli/pkg/find"
@@ -13,7 +14,12 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var log = logging.Logger("ipni-cli")
+
 func main() {
+	// Disable logging that happens in packages such as data-transfer.
+	_ = logging.SetLogLevel("*", "fatal")
+
 	app := &cli.App{
 		Name:    "ipni",
 		Usage:   "Commands to interact with IPNI indexers and index providers",

--- a/cmd/ipni/ipni.go
+++ b/cmd/ipni/ipni.go
@@ -14,8 +14,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var log = logging.Logger("ipni-cli")
-
 func main() {
 	// Disable logging that happens in packages such as data-transfer.
 	_ = logging.SetLogLevel("*", "fatal")

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/filecoin-project/go-address v1.1.0
 	github.com/ipfs/go-cid v0.4.1
 	github.com/ipfs/go-datastore v0.6.0
+	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-car/v2 v2.10.0
 	github.com/ipld/go-ipld-prime v0.20.0
 	github.com/ipni/go-libipni v0.2.10
@@ -74,7 +75,6 @@ require (
 	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
 	github.com/ipfs/go-libipfs v0.6.2 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
-	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/ipfs/go-merkledag v0.10.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
 	github.com/ipfs/go-peertaskqueue v0.8.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/ipld/go-car/v2 v2.10.0
 	github.com/ipld/go-ipld-prime v0.20.0
-	github.com/ipni/go-libipni v0.2.10
+	github.com/ipni/go-libipni v0.2.12
 	github.com/libp2p/go-libp2p v0.28.1
 	github.com/mattn/go-isatty v0.0.19
 	github.com/montanaflynn/stats v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,8 @@ github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvB
 github.com/ipld/go-ipld-prime v0.20.0 h1:Ud3VwE9ClxpO2LkCYP7vWPc0Fo+dYdYzgxUJZ3uRG4g=
 github.com/ipld/go-ipld-prime v0.20.0/go.mod h1:PzqZ/ZR981eKbgdr3y2DJYeD/8bgMawdGVlJDE8kK+M=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20230102063945-1a409dc236dd h1:gMlw/MhNr2Wtp5RwGdsW23cs+yCuj9k2ON7i9MiJlRo=
-github.com/ipni/go-libipni v0.2.10 h1:XDEchmQwkrD/c67Fk3+dVcpdxcKPz5NbsPSAAjqF2Bs=
-github.com/ipni/go-libipni v0.2.10/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
+github.com/ipni/go-libipni v0.2.12 h1:vR8fuUUdqTpBrykojxV7uFdkHLOV8RmtUtSFTQJR0yk=
+github.com/ipni/go-libipni v0.2.12/go.mod h1:dhBH9HwxT6HzQPRZ8ikWv+ccqF8ucMIoGiiTSrHA4tw=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=

--- a/pkg/adpub/client.go
+++ b/pkg/adpub/client.go
@@ -25,13 +25,15 @@ import (
 type Client interface {
 	GetAdvertisement(context.Context, cid.Cid) (*Advertisement, error)
 	Close() error
+	ClearStore()
 	Distance(context.Context, cid.Cid, cid.Cid) (int, cid.Cid, error)
 	List(context.Context, cid.Cid, int, io.Writer) error
 	SyncEntriesWithRetry(context.Context, cid.Cid) error
 }
 
 type client struct {
-	entriesDepthLimit selector.RecursionLimit
+	adChainDepthLimit int64
+	entriesDepthLimit int64
 	maxSyncRetry      uint64
 	syncRetryBackoff  time.Duration
 
@@ -72,6 +74,7 @@ func NewClient(addrInfo peer.AddrInfo, options ...Option) (Client, error) {
 		})).Node()
 
 	return &client{
+		adChainDepthLimit: opts.adChainDepthLimit,
 		entriesDepthLimit: opts.entriesDepthLimit,
 		maxSyncRetry:      opts.maxSyncRetry,
 		syncRetryBackoff:  opts.syncRetryBackoff,
@@ -97,8 +100,7 @@ func (c *client) Distance(ctx context.Context, oldestCid, newestCid cid.Cid) (in
 	}
 
 	// Sync the advertisement without entries first.
-	var err error
-	_, err = c.syncAdWithRetry(ctx, oldestCid)
+	_, err := c.syncAdWithRetry(ctx, oldestCid)
 	if err != nil {
 		return 0, cid.Undef, err
 	}
@@ -109,8 +111,12 @@ func (c *client) Distance(ctx context.Context, oldestCid, newestCid cid.Cid) (in
 		return 0, cid.Undef, err
 	}
 
-	// TODO: Allow a maximum depth to be specified for the ad chain.
-	rLimit := selector.RecursionLimitNone()
+	var rLimit selector.RecursionLimit
+	if c.adChainDepthLimit == 0 {
+		rLimit = selector.RecursionLimitNone()
+	} else {
+		rLimit = selector.RecursionLimitDepth(c.adChainDepthLimit)
+	}
 
 	stopAt := cidlink.Link{Cid: ad.PreviousID}
 
@@ -127,7 +133,7 @@ func (c *client) Distance(ctx context.Context, oldestCid, newestCid cid.Cid) (in
 		return 0, cid.Undef, err
 	}
 
-	dist, err := c.store.distance(ctx, oldestCid, newestCid)
+	dist, err := c.store.distance(ctx, oldestCid, newestCid, c.adChainDepthLimit)
 	if err != nil {
 		return 0, cid.Undef, err
 	}
@@ -180,6 +186,9 @@ func (c *client) GetAdvertisement(ctx context.Context, adCid cid.Cid) (*Advertis
 }
 
 func (c *client) syncAdWithRetry(ctx context.Context, adCid cid.Cid) (cid.Cid, error) {
+	if c.maxSyncRetry == 0 {
+		return c.sub.Sync(ctx, c.publisher, adCid, c.adSel)
+	}
 	var attempt uint64
 	var err error
 	for {
@@ -204,7 +213,13 @@ func (c *client) syncAdWithRetry(ctx context.Context, adCid cid.Cid) (cid.Cid, e
 
 func (c *client) SyncEntriesWithRetry(ctx context.Context, id cid.Cid) error {
 	var attempt uint64
-	recurLimit := c.entriesDepthLimit
+	var recurLimit selector.RecursionLimit
+	if c.entriesDepthLimit == 0 {
+		recurLimit = selector.RecursionLimitNone()
+	} else {
+		recurLimit = selector.RecursionLimitDepth(c.entriesDepthLimit)
+	}
+
 	for {
 		sel := selectEntriesWithLimit(recurLimit)
 		_, err := c.sub.Sync(ctx, c.publisher, id, sel)
@@ -249,4 +264,8 @@ func (c *client) findNextMissingChunkLink(ctx context.Context, next cid.Cid) (ci
 
 func (c *client) Close() error {
 	return c.sub.Close()
+}
+
+func (c *client) ClearStore() {
+	c.store.clear()
 }

--- a/pkg/adpub/options.go
+++ b/pkg/adpub/options.go
@@ -4,12 +4,16 @@ import (
 	"errors"
 	"fmt"
 	"time"
+)
 
-	"github.com/ipld/go-ipld-prime/traversal/selector"
+const (
+	defaultAdChainDepthLimit = 50000
+	defaultEntriesDepthLimit = 1000
 )
 
 type config struct {
-	entriesDepthLimit selector.RecursionLimit
+	adChainDepthLimit int64
+	entriesDepthLimit int64
 	maxSyncRetry      uint64
 	syncRetryBackoff  time.Duration
 	topic             string
@@ -21,9 +25,9 @@ type Option func(*config) error
 // getOpts creates a config and applies Options to it.
 func getOpts(opts []Option) (config, error) {
 	cfg := config{
-		entriesDepthLimit: selector.RecursionLimitNone(),
+		adChainDepthLimit: defaultAdChainDepthLimit,
+		entriesDepthLimit: defaultEntriesDepthLimit,
 		topic:             "/indexer/ingest/mainnet",
-		maxSyncRetry:      3,
 		syncRetryBackoff:  500 * time.Millisecond,
 	}
 
@@ -33,6 +37,18 @@ func getOpts(opts []Option) (config, error) {
 		}
 	}
 	return cfg, nil
+}
+
+// WithAdChainDepthLimit sets the depth limit when syncing an advertisement
+// chain. Setting to 0 means no limit.
+func WithAdChainDepthLimit(limit int64) Option {
+	return func(c *config) error {
+		if limit < 0 {
+			return errors.New("ad chain depth limit cannot be negative")
+		}
+		c.adChainDepthLimit = limit
+		return nil
+	}
 }
 
 // WithSyncRetryBackoff sets the length of time to wait before retrying a faild
@@ -69,11 +85,7 @@ func WithEntriesDepthLimit(depthLimit int64) Option {
 		if depthLimit < 0 {
 			return errors.New("ad entries depth limit cannot be negative")
 		}
-		if depthLimit == 0 {
-			c.entriesDepthLimit = selector.RecursionLimitNone()
-		} else {
-			c.entriesDepthLimit = selector.RecursionLimitDepth(depthLimit)
-		}
+		c.entriesDepthLimit = depthLimit
 		return nil
 	}
 }

--- a/pkg/adpub/options.go
+++ b/pkg/adpub/options.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultAdChainDepthLimit = 50000
+	defaultAdChainDepthLimit = 10000
 	defaultEntriesDepthLimit = 1000
 )
 

--- a/pkg/ads/dist.go
+++ b/pkg/ads/dist.go
@@ -63,7 +63,7 @@ func adsDistAction(cctx *cli.Context) error {
 		endStr = "head"
 	}
 
-	adCount, err := provClient.Distance(cctx.Context, startCid, endCid)
+	adCount, _, err := provClient.Distance(cctx.Context, startCid, endCid)
 	if err != nil {
 		return err
 	}

--- a/pkg/dtrack/distance_tracker.go
+++ b/pkg/dtrack/distance_tracker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/ipni/go-libipni/pcache"
 	"github.com/ipni/ipni-cli/pkg/adpub"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/multiformats/go-multiaddr"
 )
 
 type DistanceUpdate struct {
@@ -28,13 +27,11 @@ const (
 )
 
 type distTrack struct {
-	dist      int
-	head      cid.Cid
-	ad        cid.Cid
-	client    adpub.Client
-	publisher peer.AddrInfo
-	err       error
-	errType   int
+	dist    int
+	head    cid.Cid
+	ad      cid.Cid
+	err     error
+	errType int
 }
 
 func RunDistanceTracker(ctx context.Context, include, exclude map[peer.ID]struct{}, provCache *pcache.ProviderCache, updateIn time.Duration) <-chan DistanceUpdate {
@@ -222,16 +219,4 @@ func updateTrack(ctx context.Context, pid peer.ID, track *distTrack, provCache *
 		ID:       pid,
 		Distance: track.dist,
 	}
-}
-
-func maddrsEqual(a, b []multiaddr.Multiaddr) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if !a[i].Equal(b[i]) {
-			return false
-		}
-	}
-	return true
 }

--- a/pkg/dtrack/distance_tracker.go
+++ b/pkg/dtrack/distance_tracker.go
@@ -1,0 +1,237 @@
+package dtrack
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipni/go-libipni/pcache"
+	"github.com/ipni/ipni-cli/pkg/adpub"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+)
+
+type DistanceUpdate struct {
+	ID       peer.ID
+	Distance int
+	Err      error
+}
+
+const (
+	errTypeNone = iota
+	errTypeNoPublisher
+	errTypeNoSync
+	errTypePubClient
+	errTypeUpdate
+)
+
+type distTrack struct {
+	dist      int
+	head      cid.Cid
+	ad        cid.Cid
+	client    adpub.Client
+	publisher peer.AddrInfo
+	err       error
+	errType   int
+}
+
+func RunDistanceTracker(ctx context.Context, include, exclude map[peer.ID]struct{}, provCache *pcache.ProviderCache, updateIn time.Duration) <-chan DistanceUpdate {
+	updates := make(chan DistanceUpdate)
+	go runTracker(ctx, include, exclude, provCache, updateIn, updates)
+
+	return updates
+}
+
+func runTracker(ctx context.Context, include, exclude map[peer.ID]struct{}, provCache *pcache.ProviderCache, updateIn time.Duration, updates chan<- DistanceUpdate) {
+	defer close(updates)
+
+	var lookForNew bool
+	var tracks map[peer.ID]*distTrack
+	if len(include) == 0 {
+		lookForNew = true
+		tracks = make(map[peer.ID]*distTrack)
+	} else {
+		tracks = make(map[peer.ID]*distTrack, len(include))
+		for pid := range include {
+			if _, ok := exclude[pid]; ok {
+				continue
+			}
+			tracks[pid] = &distTrack{}
+		}
+	}
+
+	timer := time.NewTimer(time.Millisecond)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-timer.C:
+			if err := provCache.Refresh(ctx); err != nil {
+				return
+			}
+			if lookForNew {
+				for _, pinfo := range provCache.List() {
+					pid := pinfo.AddrInfo.ID
+					if _, ok := tracks[pid]; !ok {
+						if _, ok = exclude[pid]; !ok {
+							tracks[pid] = &distTrack{}
+						}
+					}
+				}
+			}
+			updateTracks(ctx, provCache, tracks, updates)
+			timer.Reset(updateIn)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func updateTracks(ctx context.Context, provCache *pcache.ProviderCache, tracks map[peer.ID]*distTrack, updates chan<- DistanceUpdate) {
+	var wg sync.WaitGroup
+	for providerID, dtrack := range tracks {
+		wg.Add(1)
+		go func(pid peer.ID, track *distTrack) {
+			updateTrack(ctx, pid, track, provCache, updates)
+			wg.Done()
+		}(providerID, dtrack)
+	}
+	wg.Wait()
+}
+
+func updateTrack(ctx context.Context, pid peer.ID, track *distTrack, provCache *pcache.ProviderCache, updates chan<- DistanceUpdate) {
+	pinfo, err := provCache.Get(ctx, pid)
+	if err != nil {
+		return
+	}
+
+	if pinfo.LastAdvertisement == cid.Undef {
+		if track.errType != errTypeNoSync {
+			track.errType = errTypeNoSync
+			track.err = fmt.Errorf("provider never synced")
+			updates <- DistanceUpdate{
+				ID:  pid,
+				Err: track.err,
+			}
+		}
+		return
+	}
+
+	if pinfo.Publisher == nil || pinfo.Publisher.ID.Validate() != nil || len(pinfo.Publisher.Addrs) == 0 {
+		if track.errType != errTypeNoPublisher {
+			track.errType = errTypeNoPublisher
+			track.err = fmt.Errorf("no advertisement publisher")
+			updates <- DistanceUpdate{
+				ID:  pid,
+				Err: track.err,
+			}
+		}
+		return
+	}
+
+	pubClient, err := adpub.NewClient(*pinfo.Publisher)
+	if err != nil {
+		if track.errType != errTypePubClient {
+			track.errType = errTypePubClient
+			track.err = fmt.Errorf("cannot create publisher client: %w", err)
+			updates <- DistanceUpdate{
+				ID:  pid,
+				Err: track.err,
+			}
+		}
+		return
+	}
+	defer pubClient.Close()
+
+	if track.head == cid.Undef {
+		dist, head, err := pubClient.Distance(ctx, pinfo.LastAdvertisement, cid.Undef)
+		if err != nil {
+			if track.errType != errTypeUpdate {
+				track.errType = errTypeUpdate
+				track.err = fmt.Errorf("cannot get distance update: %w", err)
+				updates <- DistanceUpdate{
+					ID:  pid,
+					Err: track.err,
+				}
+			}
+			return
+		}
+		track.err = nil
+		track.errType = errTypeNone
+		track.ad = pinfo.LastAdvertisement
+		track.dist = dist
+		track.head = head
+		updates <- DistanceUpdate{
+			ID:       pid,
+			Distance: dist,
+		}
+		return
+	}
+
+	var updated bool
+
+	// Get distance between old head and new head.
+	dist, head, err := pubClient.Distance(ctx, track.head, cid.Undef)
+	if err != nil {
+		if track.errType != errTypeUpdate {
+			track.errType = errTypeUpdate
+			track.err = fmt.Errorf("cannot get distance update: %w", err)
+			updates <- DistanceUpdate{
+				ID:  pid,
+				Err: track.err,
+			}
+		}
+		return
+	}
+	track.err = nil
+	track.errType = errTypeNone
+	if head != track.head {
+		track.dist += dist
+		track.head = head
+		updated = true
+	}
+
+	if pinfo.LastAdvertisement != track.ad {
+		// If the last seen advertisement has changed, then get the distance it has moved.
+		dist, _, err := pubClient.Distance(ctx, track.ad, pinfo.LastAdvertisement)
+		if err != nil {
+			if track.errType != errTypeUpdate {
+				track.errType = errTypeUpdate
+				track.err = fmt.Errorf("cannot get distance update: %w", err)
+				updates <- DistanceUpdate{
+					ID:  pid,
+					Err: track.err,
+				}
+			}
+			return
+		}
+		track.err = nil
+		track.errType = errTypeNone
+		track.ad = pinfo.LastAdvertisement
+		track.dist -= dist
+		updated = true
+	}
+
+	if !updated {
+		return
+	}
+
+	updates <- DistanceUpdate{
+		ID:       pid,
+		Distance: track.dist,
+	}
+}
+
+func maddrsEqual(a, b []multiaddr.Multiaddr) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -241,8 +241,8 @@ func showProviderInfo(cctx *cli.Context, pinfo *model.ProviderInfo) {
 	}
 	fmt.Println("    LastAdvertisement:", adCidStr)
 	fmt.Println("    LastAdvertisementTime:", timeStr)
-	if adCidStr != "" {
-		fmt.Println("    Lag:", pinfo.Lag)
+	if adCidStr != "" && pinfo.Lag != 0 {
+		fmt.Println("    Sync-in-progress lag:", pinfo.Lag)
 	}
 	if pinfo.Publisher != nil {
 		fmt.Println("    Publisher:", pinfo.Publisher.ID)
@@ -269,7 +269,7 @@ func showProviderInfo(cctx *cli.Context, pinfo *model.ProviderInfo) {
 
 	if cctx.Bool("distance") {
 		fmt.Print("    Distance to head advertisement: ")
-		dist, err := getLastSeenDistance(cctx, pinfo)
+		dist, _, err := getLastSeenDistance(cctx, pinfo)
 		if err != nil {
 			fmt.Println("error:", err)
 		} else {
@@ -280,16 +280,16 @@ func showProviderInfo(cctx *cli.Context, pinfo *model.ProviderInfo) {
 	fmt.Println()
 }
 
-func getLastSeenDistance(cctx *cli.Context, pinfo *model.ProviderInfo) (int, error) {
+func getLastSeenDistance(cctx *cli.Context, pinfo *model.ProviderInfo) (int, cid.Cid, error) {
 	if pinfo.Publisher == nil {
-		return 0, errors.New("no publisher listed")
+		return 0, cid.Undef, errors.New("no publisher listed")
 	}
 	if !pinfo.LastAdvertisement.Defined() {
-		return 0, errors.New("no last advertisement")
+		return 0, cid.Undef, errors.New("no last advertisement")
 	}
 	pubClient, err := adpub.NewClient(*pinfo.Publisher)
 	if err != nil {
-		return 0, err
+		return 0, cid.Undef, err
 	}
 	return pubClient.Distance(cctx.Context, pinfo.LastAdvertisement, cid.Undef)
 }


### PR DESCRIPTION
The provider command has a new `--follow-dist` option that continues to show distance updates for providers. There is also a `dtrack` package that implements distance tracking and may be used in a service that displays such information.

- Add `dtrack` package that has distance-tracking functionality
- New provider flag to track distance updates
- Default limit to ad chain depth
- Default limit to entries chain depth
- Proper error message if ad chain depth limit hit
- Disable logging that is done by dependencies
- Do not show IndexCount in provider information
- Update README to show that URLs should begin with "http://" or "https://"