### PR TITLE
Fix entry verification and use double-hashing with verify ingest

### DIFF
--- a/pkg/find/find.go
+++ b/pkg/find/find.go
@@ -25,6 +25,7 @@ var FindCmd = &cli.Command{
 Example usage:
 	ipni find -i cid.contact --cid bafybeigvgzoolc3drupxhlevdp2ugqcrbcsqfmcek2zxiw5wctk3xjpjwy`,
 	Flags:  findFlags,
+	Before: beforeFind,
 	Action: findAction,
 }
 
@@ -41,15 +42,13 @@ var findFlags = []cli.Flag{
 	},
 	&cli.StringSliceFlag{
 		Name:    "indexer",
-		Usage:   "URL of indexer to query. Multiple OK to specify providers info sources.",
+		Usage:   "URL of indexer to query. Multiple OK to specify providers info sources for dhstore.",
 		Aliases: []string{"i"},
-		Value:   cli.NewStringSlice("http://localhost:3000"),
 	},
 	&cli.StringFlag{
-		Name:     "dhstore",
-		Usage:    "URL of double-hashed (reader-private) store, if different from indexer",
-		EnvVars:  []string{"DHSTORE"},
-		Required: false,
+		Name:    "dhstore",
+		Usage:   "URL of double-hashed (reader-private) store, if different from indexer",
+		Aliases: []string{"dhs"},
 	},
 	&cli.BoolFlag{
 		Name:  "id-only",
@@ -63,6 +62,18 @@ var findFlags = []cli.Flag{
 		Name:  "fallback",
 		Usage: "Do non-private query only if the indexer does not support reader-privacy",
 	},
+}
+
+func beforeFind(cctx *cli.Context) error {
+	if len(cctx.StringSlice("indexer")) == 0 {
+		if cctx.Bool("no-priv") {
+			return cli.Exit("missing value for --indexer", 1)
+		}
+		if cctx.String("dhstore") == "" {
+			return cli.Exit("missing value for --dhstore and --indexer", 1)
+		}
+	}
+	return nil
 }
 
 func findAction(cctx *cli.Context) error {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -127,9 +127,11 @@ func providerAction(cctx *cli.Context) error {
 	var pc *pcache.ProviderCache
 	var err error
 	if len(peerIDs) > 1 {
-		pc, err = pcache.New(pcache.WithSourceURL(cctx.StringSlice("indexer")...))
+		pc, err = pcache.New(pcache.WithRefreshInterval(0),
+			pcache.WithSourceURL(cctx.StringSlice("indexer")...))
 	} else {
-		pc, err = pcache.New(pcache.WithPreload(false), pcache.WithSourceURL(cctx.StringSlice("indexer")...))
+		pc, err = pcache.New(pcache.WithPreload(false), pcache.WithRefreshInterval(0),
+			pcache.WithSourceURL(cctx.StringSlice("indexer")...))
 	}
 	if err != nil {
 		return err
@@ -173,7 +175,8 @@ func getProvider(cctx *cli.Context, pc *pcache.ProviderCache, peerID peer.ID) er
 }
 
 func countProviders(cctx *cli.Context) error {
-	pcache, err := pcache.New(pcache.WithSourceURL(cctx.StringSlice("indexer")...))
+	pcache, err := pcache.New(pcache.WithRefreshInterval(0),
+		pcache.WithSourceURL(cctx.StringSlice("indexer")...))
 	if err != nil {
 		return err
 	}
@@ -183,7 +186,8 @@ func countProviders(cctx *cli.Context) error {
 }
 
 func listProviders(cctx *cli.Context, peerIDs []peer.ID) error {
-	pc, err := pcache.New(pcache.WithSourceURL(cctx.StringSlice("indexer")...))
+	pc, err := pcache.New(pcache.WithRefreshInterval(0),
+		pcache.WithSourceURL(cctx.StringSlice("indexer")...))
 	if err != nil {
 		return err
 	}
@@ -253,7 +257,7 @@ func showProviderInfo(cctx *cli.Context, pinfo *model.ProviderInfo) {
 	if pinfo.FrozenAtTime != "" {
 		fmt.Println("    FrozenAtTime:", pinfo.FrozenAtTime)
 	}
-	fmt.Println("    IndexCount:", pinfo.IndexCount)
+
 	if pinfo.Inactive {
 		fmt.Println("    Inactive: true")
 	}

--- a/pkg/verify/ingest.go
+++ b/pkg/verify/ingest.go
@@ -724,9 +724,6 @@ func doDHFind(ctx context.Context, cl *client.DHashClient, mhs []multihash.Multi
 			resp.MultihashResults = append(resp.MultihashResults, r.MultihashResults...)
 		}
 	}
-	//if resp == nil && cctx.Bool("fallback") {
-	//	return clearFind(cctx, mhs)
-	//}
 	return resp, nil
 }
 

--- a/pkg/verify/ingest.go
+++ b/pkg/verify/ingest.go
@@ -669,11 +669,7 @@ func verifyIngest(cctx *cli.Context, find *client.Client, dhFind *client.DHashCl
 		return result, nil
 	}
 
-	if dhFind != nil {
-		fmt.Println("🔒 Reader privacy enabled")
-	}
-
-	if len(response.MultihashResults) == 0 {
+	if response == nil || len(response.MultihashResults) == 0 {
 		result.Absent = mhsCount
 		return result, nil
 	}
@@ -724,6 +720,7 @@ func doDHFind(ctx context.Context, cl *client.DHashClient, mhs []multihash.Multi
 			resp.MultihashResults = append(resp.MultihashResults, r.MultihashResults...)
 		}
 	}
+	fmt.Println("🔒 Reader privacy enabled")
 	return resp, nil
 }
 


### PR DESCRIPTION
- Need to sync entries before sampling
- Verify can now do a double-hashed find
- Make dh and non-dh verify configurable with --no-priv flag
- Optionally allow separate dhstore and indexers (provider sources) to be specified

Fixes #35