### PR TITLE
Update distance tracking one provider at a time

### DIFF
--- a/pkg/dtrack/distance_tracker.go
+++ b/pkg/dtrack/distance_tracker.go
@@ -3,7 +3,6 @@ package dtrack
 import (
 	"context"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/ipfs/go-cid"
@@ -88,15 +87,9 @@ func runTracker(ctx context.Context, include, exclude map[peer.ID]struct{}, prov
 }
 
 func updateTracks(ctx context.Context, provCache *pcache.ProviderCache, tracks map[peer.ID]*distTrack, depthLimit int64, updates chan<- DistanceUpdate) {
-	var wg sync.WaitGroup
-	for providerID, dtrack := range tracks {
-		wg.Add(1)
-		go func(pid peer.ID, track *distTrack) {
-			updateTrack(ctx, pid, track, provCache, depthLimit, updates)
-			wg.Done()
-		}(providerID, dtrack)
+	for providerID, track := range tracks {
+		updateTrack(ctx, providerID, track, provCache, depthLimit, updates)
 	}
-	wg.Wait()
 }
 
 func updateTrack(ctx context.Context, pid peer.ID, track *distTrack, provCache *pcache.ProviderCache, depthLimit int64, updates chan<- DistanceUpdate) {

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.0.6"
+  "version": "v0.0.7"
 }


### PR DESCRIPTION
Distance tracking needs to run without taking excessibe memory, and this is bounded by setting the max advertisement chain depth. If there is unbounded concurrency, that is measuring all providers at the same time, then memory consumption can no longer be bounded.