### PR TITLE
Fix entries retrieval

### DIFF
--- a/pkg/adpub/entries_iter.go
+++ b/pkg/adpub/entries_iter.go
@@ -53,7 +53,6 @@ func isPresent(c cid.Cid) bool {
 }
 
 func (d *EntriesIterator) Next() (multihash.Multihash, error) {
-
 	if !d.IsPresent() {
 		return nil, io.EOF
 	}

--- a/pkg/ads/get.go
+++ b/pkg/ads/get.go
@@ -192,7 +192,10 @@ func adsGetAction(cctx *cli.Context) error {
 			err = pubClient.SyncEntriesWithRetry(cctx.Context, ad.Entries.Root())
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "⚠️ Failed to sync entries for advertisement %s. %s\n", ad.ID, err)
+				continue
 			}
+		} else {
+			fmt.Println("No entries")
 			continue
 		}
 


### PR DESCRIPTION
- Fix retrieving entries from store. Need to sync entries into same store used by ad entries iterator.
- Fix retreiving entreis using dtsync. Cannot have multiple dtsync subscribers in same process.