### PR TITLE
Flag to show only publisher addr info

### DIFF
--- a/doc/provider-head-ad.md
+++ b/doc/provider-head-ad.md
@@ -1,0 +1,14 @@
+## Get the Head Advertisement for Providers
+
+The get the head advertisement for every provider:
+
+```shell
+ipni provider --all --i=https://cid.contact --publisher | xargs -I addrinfo -R 1 ipni ads get --head --ai addrinfo
+```
+
+To get the head advertisement for a single provider:
+
+```shell
+ipni provider --pid=12D3KooWC8QzjdzWynwYybjDLKa1YbPiRXUjwsibERubatgmQP51 --i=https://cid.contact --publisher | xargs ipni ads get --head --ai
+```
+

--- a/pkg/ads/flags.go
+++ b/pkg/ads/flags.go
@@ -9,8 +9,8 @@ import (
 var addrInfoFlag = &cli.StringFlag{
 	Name: "addr-info",
 	Usage: "Publisher's address info in form of libp2p multiaddr info.\n" +
-		"Example GraphSync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
-		"Example HTTP:      /ip4/1.2.3.4/tcp/1234/http/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+		"Example ipnisync: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ\n" +
+		"Example HTTP:     /ip4/1.2.3.4/tcp/1234/http/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
 	Aliases:  []string{"ai"},
 	Required: true,
 }


### PR DESCRIPTION
- Add flag, to `provider` command, that shown only publisher address info.
- Add documentation to show how to get the head advertisement for each provider.