### PR TITLE
Add "--protocol" flag to provider command

### DIFF
--- a/pkg/dtrack/option.go
+++ b/pkg/dtrack/option.go
@@ -31,6 +31,14 @@ func WithDepthLimit(limit int64) Option {
 	}
 }
 
+// WithP2pHost configures the libp2p host to use for connection to the
+// advertisement publisher.
+func WithP2pHost(p2pHost host.Host) Option {
+	return func(c *config) {
+		c.p2pHost = p2pHost
+	}
+}
+
 // WithTopic configures the topic name used to get the head advertisement when
 // using data-transfer/graphsync.
 func WithTopic(topic string) Option {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -58,8 +58,9 @@ var providerFlags = []cli.Flag{
 		Usage: "Count all providers and output only the count. Implies --all",
 	},
 	&cli.BoolFlag{
-		Name:  "distance",
-		Usage: "Calculate distance from last seen advertisement to provider's current head advertisement",
+		Name:    "distance",
+		Usage:   "Calculate distance from last seen advertisement to provider's current head advertisement",
+		Aliases: []string{"dist"},
 	},
 	&cli.BoolFlag{
 		Name:  "diff-pub",
@@ -103,7 +104,7 @@ var providerFlags = []cli.Flag{
 	&cli.BoolFlag{
 		Name:    "protocol",
 		Aliases: []string{"proto"},
-		Usage:   "Print publisher protocol.",
+		Usage:   "Print publisher's protocol used to publish advertisements.",
 	},
 	&cli.BoolFlag{
 		Name:    "publisher",


### PR DESCRIPTION
Specifying the "--protocol" flag to the provider command shows the publisher's protocol (http, libp2phttp, data-transfer/graphsync).