### PR TITLE
Print metadata bytes and protocols

### DIFF
--- a/pkg/ads/get.go
+++ b/pkg/ads/get.go
@@ -146,14 +146,23 @@ func adsGetAction(cctx *cli.Context) error {
 			fmt.Fprintf(os.Stderr, "⚠️  Failed to fully sync advertisement %s. Output shows partially synced ad.\n  Error: %s\n", adCid, err.Error())
 		}
 
-		fmt.Printf("CID:          %s\n", ad.ID)
+		fmt.Println("CID:", ad.ID)
 		var prevCID string
 		if ad.PreviousID != cid.Undef {
 			prevCID = ad.PreviousID.String()
 		}
 
-		var mdProtos []string
-		if len(ad.Metadata) != 0 {
+		fmt.Println("PreviousCID:", prevCID)
+		fmt.Println("ProviderID:", ad.ProviderID)
+		fmt.Println("ContextID:", base64.StdEncoding.EncodeToString(ad.ContextID))
+		fmt.Println("Addresses:", ad.Addresses)
+		fmt.Println("Is Remove:", ad.IsRemove)
+		fmt.Print("Metadata: ")
+		if len(ad.Metadata) == 0 {
+			fmt.Println("none")
+		} else {
+			fmt.Println(base64.StdEncoding.EncodeToString(ad.Metadata))
+			var mdProtos []string
 			md := metadata.Default.New()
 			err = md.UnmarshalBinary(ad.Metadata)
 			if err == nil {
@@ -161,35 +170,27 @@ func adsGetAction(cctx *cli.Context) error {
 					mdProtos = append(mdProtos, p.String())
 				}
 			}
-		}
-
-		fmt.Printf("PreviousCID:  %s\n", prevCID)
-		fmt.Printf("ProviderID:   %s\n", ad.ProviderID)
-		fmt.Printf("ContextID:    %s\n", base64.StdEncoding.EncodeToString(ad.ContextID))
-		fmt.Printf("Addresses:    %v\n", ad.Addresses)
-		fmt.Printf("Is Remove:    %v\n", ad.IsRemove)
-		fmt.Print("Metadata:     ")
-		if len(mdProtos) != 0 {
-			fmt.Println(strings.Join(mdProtos, " "))
-		} else {
-			fmt.Println(base64.StdEncoding.EncodeToString(ad.Metadata))
+			if len(mdProtos) != 0 {
+				fmt.Print("  Protocols: ")
+				fmt.Println(strings.Join(mdProtos, " "))
+			}
 		}
 
 		fmt.Println("Extended Providers:")
 		if ad.ExtendedProvider != nil {
-			fmt.Printf("   Override: %v\n", ad.ExtendedProvider.Override)
-			fmt.Println("   Providers:")
+			fmt.Printf("  Override: %v\n", ad.ExtendedProvider.Override)
+			fmt.Println("  Providers:")
 			if len(ad.ExtendedProvider.Providers) != 0 {
 				for i, ep := range ad.ExtendedProvider.Providers {
-					fmt.Printf("    %d. ID:         %v\n", i+1, ep.ID)
-					fmt.Printf("        Addresses:  %v\n", ep.Addresses)
-					fmt.Printf("        Metadata:   %v\n", base64.StdEncoding.EncodeToString(ep.Metadata))
+					fmt.Printf("   %d. ID:         %v\n", i+1, ep.ID)
+					fmt.Printf("       Addresses:  %v\n", ep.Addresses)
+					fmt.Printf("       Metadata:   %v\n", base64.StdEncoding.EncodeToString(ep.Metadata))
 				}
 			} else {
-				fmt.Println("      None")
+				fmt.Println("     None")
 			}
 		} else {
-			fmt.Println("   None")
+			fmt.Println("  None")
 		}
 		fmt.Print("Signature: ")
 		if ad.SigErr != nil {

--- a/pkg/find/find.go
+++ b/pkg/find/find.go
@@ -41,6 +41,7 @@ var findFlags = []cli.Flag{
 		Name:    "indexer",
 		Usage:   "URL of indexer to query. Multiple OK to specify providers info sources for dhstore.",
 		Aliases: []string{"i"},
+		Value:   cli.NewStringSlice("https://cid.contact"),
 	},
 	&cli.StringFlag{
 		Name:    "dhstore",
@@ -176,17 +177,20 @@ func printResults(cctx *cli.Context, resp *model.FindResponse) error {
 			fmt.Println("  Provider:", provStr)
 			for _, pr := range prs {
 				fmt.Println("    ContextID:", base64.StdEncoding.EncodeToString(pr.ContextID))
-				fmt.Println("      Metadata:", decodeMetadata(pr.Metadata))
+				fmt.Print("      Metadata: ")
+				if len(pr.Metadata) == 0 {
+					fmt.Println("none")
+				} else {
+					fmt.Println(base64.StdEncoding.EncodeToString(pr.Metadata))
+					fmt.Println("        Protocols:", decodeMetadataProtos(pr.Metadata))
+				}
 			}
 		}
 	}
 	return nil
 }
 
-func decodeMetadata(metaBytes []byte) string {
-	if len(metaBytes) == 0 {
-		return "nil"
-	}
+func decodeMetadataProtos(metaBytes []byte) string {
 	meta := metadata.Default.New()
 	err := meta.UnmarshalBinary(metaBytes)
 	if err != nil {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -42,10 +42,10 @@ Here is an example that shows using the output of one provider command to filter
 
 var providerFlags = []cli.Flag{
 	&cli.StringSliceFlag{
-		Name:     "indexer",
-		Usage:    "Indexer URL. Specifying multiple results in a unified view of providers across all.",
-		Aliases:  []string{"i"},
-		Required: true,
+		Name:    "indexer",
+		Usage:   "Indexer URL. Specifying multiple results in a unified view of providers across all.",
+		Aliases: []string{"i"},
+		Value:   cli.NewStringSlice("https://cid.contact"),
 	},
 	&cli.StringSliceFlag{
 		Name:  "pid",

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -33,10 +33,10 @@ var RandomCmd = &cli.Command{
 
 var randomFlags = []cli.Flag{
 	&cli.StringSliceFlag{
-		Name:     "indexer",
-		Usage:    "Indexer URL. Specifying multiple results in a unified view of providers across all.",
-		Aliases:  []string{"i"},
-		Required: true,
+		Name:    "indexer",
+		Usage:   "Indexer URL. Specifying multiple results in a unified view of providers across all.",
+		Aliases: []string{"i"},
+		Value:   cli.NewStringSlice("https://cid.contact"),
 	},
 	&cli.StringSliceFlag{
 		Name:  "pid",


### PR DESCRIPTION
Show the metadata bytes as a base64-encoded string, in addition to showing the protocols contained in the metadata. Showing both is necessary since different metadata can have the same protocols. For example, two metadatas each with the `transport-graphsync-filecoinv1` protocol may have different piece IDs in the data.

- Update output of `ads get` command
- Default indexer flag to "https://cid.contact"