### PR TITLE
Option to get miner ID for provider

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -121,7 +121,7 @@ var providerFlags = []cli.Flag{
 	},
 	&cli.BoolFlag{
 		Name:  "spid",
-		Usage: "Print the provider's Filecoin storage provider ID.",
+		Usage: "Print the provider's Filecoin storage provider ID. Optionally usable with --id-only.",
 	},
 	&cli.StringFlag{
 		Name:  "topic",

--- a/version.go
+++ b/version.go
@@ -20,9 +20,11 @@ var versionJSON []byte
 
 func init() {
 	// Read version from embedded JSON file.
-	var verMap map[string]string
-	json.Unmarshal(versionJSON, &verMap)
-	Release = verMap["version"]
+	var v struct {
+		Version string `json:"version"`
+	}
+	json.Unmarshal(versionJSON, &v)
+	Release = v.Version
 
 	// If running from a module, try to get the build info.
 	bi, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
Uses the filfox API to lookup a miner IDs using a peer ID. Example:
```
ipni provider --pid=12D3KooWRVff5caDVpg4b4gWZscGWonfpP7b7ucXjQGrcsSTNW2i -spid
Provider 12D3KooWRVff5caDVpg4b4gWZscGWonfpP7b7ucXjQGrcsSTNW2i
    Addresses: [/ip4/128.136.157.164/tcp/8068]
    LastAdvertisement: baguqeeratw7fq7i67bjptcdnwddvf23qqvacpnvujp3ugtq6rcledddc5zza
    LastAdvertisementTime: 2025-02-21T20:56:47Z
    Publisher: 12D3KooWRVff5caDVpg4b4gWZscGWonfpP7b7ucXjQGrcsSTNW2i
        Publisher Addrs: [/ip4/128.136.157.164/tcp/7068/http]
    SPID: f03251828

```

This can also be used with the `--id-only` option:
```
ipni provider --pid=12D3KooWRVff5caDVpg4b4gWZscGWonfpP7b7ucXjQGrcsSTNW2i --id-only -spid
12D3KooWRVff5caDVpg4b4gWZscGWonfpP7b7ucXjQGrcsSTNW2i     f03251828
```
